### PR TITLE
Recognize *.hh as (C++) headers

### DIFF
--- a/src/data/items.json
+++ b/src/data/items.json
@@ -79,7 +79,7 @@
       "zsh"
     ],
     "font": ["eot", "otf", "ttf", "woff", "woff2"],
-    "headers": ["d.ts", "h", "h++", "hpp", "hxx", "pyi"],
+    "headers": ["d.ts", "h", "h++", "hh", "hpp", "hxx", "pyi"],
     "image": [
       "gif",
       "ico",


### PR DESCRIPTION
*.hh files are not recognized as (C++) headers, so the generic icon is used. The matching *.cc extension, however, is correctly recognized as (C++) source.